### PR TITLE
Render to data buffer if needed

### DIFF
--- a/Tesseract OCR iOS.xcodeproj/project.pbxproj
+++ b/Tesseract OCR iOS.xcodeproj/project.pbxproj
@@ -9,14 +9,6 @@
 /* Begin PBXBuildFile section */
 		087F9583222016D900EF06BE /* libLeptonica.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 087F955922200F4500EF06BE /* libLeptonica.a */; };
 		087F9584222016D900EF06BE /* libtesseract.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 087F956722200F8B00EF06BE /* libtesseract.a */; };
-		087F958D222016F400EF06BE /* libLeptonica.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 087F955922200F4500EF06BE /* libLeptonica.a */; };
-		087F958E222016F400EF06BE /* libtesseract.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 087F956022200F6C00EF06BE /* libtesseract.a */; };
-		0880FE2922200023006B76FD /* G8RecognitionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE1422200023006B76FD /* G8RecognitionOperation.m */; };
-		0880FE2A22200023006B76FD /* G8TesseractParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE1822200023006B76FD /* G8TesseractParameters.m */; };
-		0880FE2B22200023006B76FD /* UIImage+G8Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE1922200023006B76FD /* UIImage+G8Filters.m */; };
-		0880FE2D22200023006B76FD /* G8Tesseract.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE1E22200023006B76FD /* G8Tesseract.mm */; };
-		0880FE2E22200023006B76FD /* UIImage+G8FixOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE2622200023006B76FD /* UIImage+G8FixOrientation.m */; };
-		0880FE2F22200023006B76FD /* G8RecognizedBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE2822200023006B76FD /* G8RecognizedBlock.m */; };
 		0880FE4822200051006B76FD /* G8RecognitionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE3322200051006B76FD /* G8RecognitionOperation.m */; };
 		0880FE4922200051006B76FD /* G8TesseractParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE3722200051006B76FD /* G8TesseractParameters.m */; };
 		0880FE4A22200051006B76FD /* UIImage+G8Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = 0880FE3822200051006B76FD /* UIImage+G8Filters.m */; };
@@ -32,13 +24,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 085A491F2216C15200183FD3;
 			remoteInfo = Leptonica;
-		};
-		087F955F22200F6C00EF06BE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 087F955A22200F6C00EF06BE /* Tesseract3.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 08D4F54721089D6A00BEB3D1;
-			remoteInfo = Tesseract3;
 		};
 		087F956622200F8B00EF06BE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -61,32 +46,9 @@
 			remoteGlobalIDString = 08D4F54621089D6A00BEB3D1;
 			remoteInfo = Tesseract4;
 		};
-		087F9589222016ED00EF06BE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 087F955322200F4500EF06BE /* Leptonica.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 085A491E2216C15200183FD3;
-			remoteInfo = Leptonica;
-		};
-		087F958B222016ED00EF06BE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 087F955A22200F6C00EF06BE /* Tesseract3.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 08D4F54621089D6A00BEB3D1;
-			remoteInfo = Tesseract3;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		085A544F2216D6CC00183FD3 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		08AFF1FA221EE986004E7B66 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -99,28 +61,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		085A54512216D6CC00183FD3 /* libg8Tesseract.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libg8Tesseract.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		087F955322200F4500EF06BE /* Leptonica.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Leptonica.xcodeproj; path = TesseractOCR/Leptonica/Leptonica.xcodeproj; sourceTree = "<group>"; };
-		087F955A22200F6C00EF06BE /* Tesseract3.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Tesseract3.xcodeproj; path = Tesseract3/Tesseract3.xcodeproj; sourceTree = "<group>"; };
 		087F956122200F8B00EF06BE /* Tesseract4.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Tesseract4.xcodeproj; path = Tesseract4/Tesseract4.xcodeproj; sourceTree = "<group>"; };
-		0880FE1322200023006B76FD /* TesseractOCR-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TesseractOCR-Prefix.pch"; sourceTree = "<group>"; };
-		0880FE1422200023006B76FD /* G8RecognitionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = G8RecognitionOperation.m; sourceTree = "<group>"; };
-		0880FE1522200023006B76FD /* G8Tesseract+PDFRendering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "G8Tesseract+PDFRendering.h"; sourceTree = "<group>"; };
-		0880FE1722200023006B76FD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		0880FE1822200023006B76FD /* G8TesseractParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = G8TesseractParameters.m; sourceTree = "<group>"; };
-		0880FE1922200023006B76FD /* UIImage+G8Filters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+G8Filters.m"; sourceTree = "<group>"; };
-		0880FE1A22200023006B76FD /* UIImage+G8FixOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+G8FixOrientation.h"; sourceTree = "<group>"; };
-		0880FE1C22200023006B76FD /* G8RecognizedBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8RecognizedBlock.h; sourceTree = "<group>"; };
-		0880FE1D22200023006B76FD /* G8Tesseract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8Tesseract.h; sourceTree = "<group>"; };
-		0880FE1E22200023006B76FD /* G8Tesseract.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = G8Tesseract.mm; sourceTree = "<group>"; };
-		0880FE2022200023006B76FD /* G8Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8Constants.h; sourceTree = "<group>"; };
-		0880FE2122200023006B76FD /* G8RecognitionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8RecognitionOperation.h; sourceTree = "<group>"; };
-		0880FE2222200023006B76FD /* G8TesseractDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8TesseractDelegate.h; sourceTree = "<group>"; };
-		0880FE2322200023006B76FD /* UIImage+G8Filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+G8Filters.h"; sourceTree = "<group>"; };
-		0880FE2422200023006B76FD /* G8TesseractParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = G8TesseractParameters.h; sourceTree = "<group>"; };
-		0880FE2622200023006B76FD /* UIImage+G8FixOrientation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+G8FixOrientation.m"; sourceTree = "<group>"; };
-		0880FE2722200023006B76FD /* TesseractOCR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TesseractOCR.h; sourceTree = "<group>"; };
-		0880FE2822200023006B76FD /* G8RecognizedBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = G8RecognizedBlock.m; sourceTree = "<group>"; };
 		0880FE3122200051006B76FD /* TesseractOCR-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TesseractOCR-Prefix.pch"; sourceTree = "<group>"; };
 		0880FE3322200051006B76FD /* G8RecognitionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = G8RecognitionOperation.m; sourceTree = "<group>"; };
 		0880FE3422200051006B76FD /* G8Tesseract+PDFRendering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "G8Tesseract+PDFRendering.h"; sourceTree = "<group>"; };
@@ -147,15 +89,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		085A544E2216D6CC00183FD3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				087F958D222016F400EF06BE /* libLeptonica.a in Frameworks */,
-				087F958E222016F400EF06BE /* libtesseract.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		08AFF1F7221EE986004E7B66 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -176,47 +109,12 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		087F955B22200F6C00EF06BE /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				087F956022200F6C00EF06BE /* libtesseract.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		087F956222200F8B00EF06BE /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				087F956722200F8B00EF06BE /* libtesseract.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		0880FE1222200023006B76FD /* G8Tess3 */ = {
-			isa = PBXGroup;
-			children = (
-				087F955A22200F6C00EF06BE /* Tesseract3.xcodeproj */,
-				0880FE1322200023006B76FD /* TesseractOCR-Prefix.pch */,
-				0880FE1422200023006B76FD /* G8RecognitionOperation.m */,
-				0880FE1522200023006B76FD /* G8Tesseract+PDFRendering.h */,
-				0880FE1622200023006B76FD /* InfoPlist.strings */,
-				0880FE1822200023006B76FD /* G8TesseractParameters.m */,
-				0880FE1922200023006B76FD /* UIImage+G8Filters.m */,
-				0880FE1A22200023006B76FD /* UIImage+G8FixOrientation.h */,
-				0880FE1C22200023006B76FD /* G8RecognizedBlock.h */,
-				0880FE1D22200023006B76FD /* G8Tesseract.h */,
-				0880FE1E22200023006B76FD /* G8Tesseract.mm */,
-				0880FE2022200023006B76FD /* G8Constants.h */,
-				0880FE2122200023006B76FD /* G8RecognitionOperation.h */,
-				0880FE2222200023006B76FD /* G8TesseractDelegate.h */,
-				0880FE2322200023006B76FD /* UIImage+G8Filters.h */,
-				0880FE2422200023006B76FD /* G8TesseractParameters.h */,
-				0880FE2622200023006B76FD /* UIImage+G8FixOrientation.m */,
-				0880FE2722200023006B76FD /* TesseractOCR.h */,
-				0880FE2822200023006B76FD /* G8RecognizedBlock.m */,
-			);
-			name = G8Tess3;
-			path = TesseractOCR/G8Tess3;
 			sourceTree = "<group>";
 		};
 		0880FE3022200051006B76FD /* G8Tess4 */ = {
@@ -250,10 +148,8 @@
 			isa = PBXGroup;
 			children = (
 				087F955322200F4500EF06BE /* Leptonica.xcodeproj */,
-				0880FE1222200023006B76FD /* G8Tess3 */,
 				0880FE3022200051006B76FD /* G8Tess4 */,
 				64F74CCB172FD75F0068E657 /* Frameworks */,
-				085A54512216D6CC00183FD3 /* libg8Tesseract.a */,
 				08AFF1FF221EE986004E7B66 /* libg8Tesseract.a */,
 			);
 			sourceTree = "<group>";
@@ -272,25 +168,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		085A54502216D6CC00183FD3 /* g8Tesseract_tess3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 085A54572216D6CC00183FD3 /* Build configuration list for PBXNativeTarget "g8Tesseract_tess3" */;
-			buildPhases = (
-				085A544D2216D6CC00183FD3 /* Sources */,
-				085A544E2216D6CC00183FD3 /* Frameworks */,
-				085A544F2216D6CC00183FD3 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				087F958A222016ED00EF06BE /* PBXTargetDependency */,
-				087F958C222016ED00EF06BE /* PBXTargetDependency */,
-			);
-			name = g8Tesseract_tess3;
-			productName = g8Tesseract;
-			productReference = 085A54512216D6CC00183FD3 /* libg8Tesseract.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		08AFF1EB221EE986004E7B66 /* g8Tesseract_tess4 */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 08AFF1FB221EE986004E7B66 /* Build configuration list for PBXNativeTarget "g8Tesseract_tess4" */;
@@ -320,11 +197,6 @@
 				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = "Daniele Galiotto - www.g8production.com";
 				TargetAttributes = {
-					085A54502216D6CC00183FD3 = {
-						CreatedOnToolsVersion = 10.1;
-						DevelopmentTeam = FRUPYT6KB3;
-						ProvisioningStyle = Automatic;
-					};
 					08AFF1EB221EE986004E7B66 = {
 						DevelopmentTeam = FRUPYT6KB3;
 						ProvisioningStyle = Automatic;
@@ -348,17 +220,12 @@
 					ProjectRef = 087F955322200F4500EF06BE /* Leptonica.xcodeproj */;
 				},
 				{
-					ProductGroup = 087F955B22200F6C00EF06BE /* Products */;
-					ProjectRef = 087F955A22200F6C00EF06BE /* Tesseract3.xcodeproj */;
-				},
-				{
 					ProductGroup = 087F956222200F8B00EF06BE /* Products */;
 					ProjectRef = 087F956122200F8B00EF06BE /* Tesseract4.xcodeproj */;
 				},
 			);
 			projectRoot = "";
 			targets = (
-				085A54502216D6CC00183FD3 /* g8Tesseract_tess3 */,
 				08AFF1EB221EE986004E7B66 /* g8Tesseract_tess4 */,
 			);
 		};
@@ -372,13 +239,6 @@
 			remoteRef = 087F955822200F4500EF06BE /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		087F956022200F6C00EF06BE /* libtesseract.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libtesseract.a;
-			remoteRef = 087F955F22200F6C00EF06BE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		087F956722200F8B00EF06BE /* libtesseract.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -389,19 +249,6 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXSourcesBuildPhase section */
-		085A544D2216D6CC00183FD3 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0880FE2922200023006B76FD /* G8RecognitionOperation.m in Sources */,
-				0880FE2E22200023006B76FD /* UIImage+G8FixOrientation.m in Sources */,
-				0880FE2F22200023006B76FD /* G8RecognizedBlock.m in Sources */,
-				0880FE2A22200023006B76FD /* G8TesseractParameters.m in Sources */,
-				0880FE2B22200023006B76FD /* UIImage+G8Filters.m in Sources */,
-				0880FE2D22200023006B76FD /* G8Tesseract.mm in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		08AFF1F0221EE986004E7B66 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -428,27 +275,9 @@
 			name = Tesseract4;
 			targetProxy = 087F9587222016E400EF06BE /* PBXContainerItemProxy */;
 		};
-		087F958A222016ED00EF06BE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Leptonica;
-			targetProxy = 087F9589222016ED00EF06BE /* PBXContainerItemProxy */;
-		};
-		087F958C222016ED00EF06BE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tesseract3;
-			targetProxy = 087F958B222016ED00EF06BE /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		0880FE1622200023006B76FD /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				0880FE1722200023006B76FD /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
 		0880FE3522200051006B76FD /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -460,200 +289,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		085A54582216D6CC00183FD3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BITCODE_GENERATION_MODE = bitcode;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = FRUPYT6KB3;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/TesseractOCR/G8Tess3/**",
-					"$(PROJECT_DIR)/TesseractOCR/Leptonica/**",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = "$(inherited)";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/TesseractOCR/lib",
-				);
-				LLVM_LTO = YES_THIN;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				OTHER_CFLAGS = "-fembed-bitcode-marker";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = g8Tesseract;
-				SKIP_INSTALL = YES;
-				STRIP_STYLE = debugging;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = "$(ARCHS_STANDARD) x86_64 i386";
-			};
-			name = Debug;
-		};
-		085A54592216D6CC00183FD3 /* Coverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BITCODE_GENERATION_MODE = bitcode;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = FRUPYT6KB3;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/TesseractOCR/G8Tess3/**",
-					"$(PROJECT_DIR)/TesseractOCR/Leptonica/**",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = "$(inherited)";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/TesseractOCR/lib",
-				);
-				LLVM_LTO = YES_THIN;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				OTHER_CFLAGS = "-fembed-bitcode";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = g8Tesseract;
-				SKIP_INSTALL = YES;
-				STRIP_STYLE = debugging;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = "$(ARCHS_STANDARD) x86_64 i386";
-			};
-			name = Coverage;
-		};
-		085A545A2216D6CC00183FD3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BITCODE_GENERATION_MODE = bitcode;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = FRUPYT6KB3;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/TesseractOCR/G8Tess3/**",
-					"$(PROJECT_DIR)/TesseractOCR/Leptonica/**",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = "$(inherited)";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/TesseractOCR/lib",
-				);
-				LLVM_LTO = YES_THIN;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				OTHER_CFLAGS = "-fembed-bitcode";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = g8Tesseract;
-				SKIP_INSTALL = YES;
-				STRIP_STYLE = debugging;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = "$(ARCHS_STANDARD) x86_64 i386";
-			};
-			name = Release;
-		};
 		08AFF1FC221EE986004E7B66 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1017,16 +652,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		085A54572216D6CC00183FD3 /* Build configuration list for PBXNativeTarget "g8Tesseract_tess3" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				085A54582216D6CC00183FD3 /* Debug */,
-				085A54592216D6CC00183FD3 /* Coverage */,
-				085A545A2216D6CC00183FD3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		08AFF1FB221EE986004E7B66 /* Build configuration list for PBXNativeTarget "g8Tesseract_tess4" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/TesseractOCR/G8Tess4/G8Tesseract+PDFRendering.h
+++ b/TesseractOCR/G8Tess4/G8Tesseract+PDFRendering.h
@@ -14,6 +14,8 @@
 
 - (BOOL)beginPDF:(NSURL *)pdfOutputURL creatorString:(NSString *)creator;
 
+- (BOOL)beginPDFDataWithCreatorString:(NSString *)creator;
+
 - (BOOL)addCurrentPageWithResolution:(int)dpi;
 
 - (BOOL)endPDF;

--- a/TesseractOCR/G8Tess4/G8Tesseract.h
+++ b/TesseractOCR/G8Tess4/G8Tesseract.h
@@ -142,6 +142,9 @@ extern NSInteger const kG8MaxCredibleResolution;
  */
 @property (nonatomic, readonly) NSString *recognizedText;
 
+
+@property (nonatomic, readonly) NSData *pdfOutputData;
+
 /**
  *  Make an HTML-formatted string with hOCR markup from the internal Tesseract
  *  data structures.


### PR DESCRIPTION
Enable rendering PDFs to a data buffer instead of a file.
Remove support for Tesseract 3.